### PR TITLE
Fix network scripts path handling

### DIFF
--- a/demo-fem-network.sh
+++ b/demo-fem-network.sh
@@ -5,6 +5,12 @@
 
 set -e
 
+# Determine repository root relative to this script so it can run from any
+# location. Fallback to the script directory if git is unavailable.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
 echo "🌟 FEM Network Demonstration"
 echo "============================"
 echo "This demo shows a complete FEP/FEM network with:"
@@ -16,7 +22,6 @@ echo ""
 
 # Build components
 echo "📦 Building FEM components..."
-cd /Users/slowbro/Workspaces/Sandbox/FEP-FEM-full
 
 # Build broker
 echo "  • fem-broker (FEP message broker)"

--- a/test-network.sh
+++ b/test-network.sh
@@ -3,12 +3,17 @@
 # Test script for FEM network functionality
 set -e
 
+# Determine repository root relative to this script so it can run from any
+# location. Fallback to the script directory if git is unavailable.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
 echo "🚀 Testing FEM Network Implementation"
 echo "======================================"
 
 # Build components
 echo "📦 Building components..."
-cd /Users/slowbro/Workspaces/Sandbox/FEP-FEM-full
 
 # Build broker
 echo "  Building broker..."


### PR DESCRIPTION
## Summary
- compute repository root in demo-fem-network.sh
- compute repository root in test-network.sh
- drop hard-coded path so scripts run from any directory

## Testing
- `make fmt`
- `make test` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849c7ff9dc48324b61b8446b526a8ae