### PR TITLE
Add gofmt check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,16 @@ jobs:
     
     - name: Install dependencies
       run: make install-deps
-    
+
+    - name: Check formatting
+      run: |
+        unformatted=$(gofmt -l $(git ls-files '*.go'))
+        if [ -n "$unformatted" ]; then
+          echo "The following files are not formatted:" >&2
+          echo "$unformatted" >&2
+          exit 1
+        fi
+
     - name: Run linter
       run: make lint
     

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 1. Fork, branch from `develop`.
 2. Run `make test` before PR.
-3. Add JSONSchema tests when modifying envelopes.
-4. Sign commits with DCO (`Signed-off-by: Name <email>`).
+3. Ensure Go files are formatted with `gofmt` (`go fmt`); CI fails if any file is unformatted.
+4. Add JSONSchema tests when modifying envelopes.
+5. Sign commits with DCO (`Signed-off-by: Name <email>`).


### PR DESCRIPTION
## Summary
- run `gofmt -l` during CI and fail if files need formatting
- note formatting requirement in CONTRIBUTING

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6849ccb177908324afd33ec510169324